### PR TITLE
Turn readme examples into individual HTML files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .*.sw?
 /node_modules/
+/readme-examples/

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "watchify": "^2.2.1"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node server.js"
+    "test": "karma start --single-run"
   },
   "keywords": [
     "virtual-dom",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "virtual-dom": "^0.0.24"
   },
   "devDependencies": {
+    "browserify": "^8.0.2",
     "chai": "^1.10.0",
     "express": "^4.10.4",
     "jquery": "^2.1.3",
@@ -16,12 +17,14 @@
     "karma-cli": "0.0.4",
     "karma-mocha": "^0.1.10",
     "karma-mocha-reporter": "^0.3.1",
+    "marked": "^0.3.2",
     "mocha": "^2.1.0",
     "trytryagain": "^0.1.0",
     "watchify": "^2.2.1"
   },
   "scripts": {
-    "test": "karma start --single-run"
+    "test": "karma start --single-run",
+    "readme-examples": "node readme-examples.js"
   },
   "keywords": [
     "virtual-dom",

--- a/readme-examples.js
+++ b/readme-examples.js
@@ -1,0 +1,66 @@
+// expands the examples in readme.md into a directory of HTML files
+
+var marked = require('marked');
+var fs = require('fs');
+var directory = './readme-examples';
+
+fs.readFile('./readme.md', 'utf-8', function(err, markdown) {
+  renderExamples(extractExamples(markdown));
+  browserifyPlastiq();
+});
+
+function extractExamples(markdown) {
+  var examples = [];
+  var heading = 'untitled';
+  var tokens = marked.lexer(markdown);
+  for (var i = 0; i < tokens.length; ++i) {
+    var token = tokens[i];
+    if (token.type == 'code') {
+      examples.push({ heading: heading, js: token.text });
+    } else if (token.type == 'heading') {
+      heading = token.text;
+    }
+  }
+  return examples;
+}
+
+function renderExamples(examples) {
+  try { fs.mkdirSync(directory); } catch (e) {}
+  for (var i = 0; i < examples.length; ++i) {
+    var example = examples[i];
+    if (shouldRenderExample(example)) {
+      var filename = example.heading.replace(" ", '-').toLowerCase() + '.html';
+      fs.writeFileSync(directory + '/' + filename, renderExample(example.js));
+    }
+  }
+}
+
+function shouldRenderExample(example) {
+  return example.js.indexOf('plastiq.attach') > -1 &&
+         example.heading != 'An Example';
+}
+
+function renderExample(example) {
+  var template = [
+    '<html>',
+    '<body>',
+    '<script src="plastiq.js"></script>',
+    '<script>',
+    'var h = plastiq.html;',
+    'var bind = plastiq.bind;',
+    '',
+    '{example}',
+    '',
+    '</script>',
+    '</body>',
+    '</html>'
+  ].join("\n");
+  return template.replace("{example}", example);
+}
+
+function browserifyPlastiq() {
+  var browserify = require('browserify');
+  var bundle = new browserify({ standalone: 'plastiq' });
+  bundle.add('./index.js');
+  bundle.bundle().pipe(fs.createWriteStream(directory + '/' + 'plastiq.js'));
+}

--- a/readme.md
+++ b/readme.md
@@ -192,44 +192,46 @@ Here we have a `render` function that contains an `addPerson` function that adds
 
 We also render several people using the `renderPerson` function, containing a `deletePerson` function to delete the person when the `delete` button is clicked.
 
-    function render(page) {
-      function addPerson() {
-        page.people.push({name: "somebody"});
-      }
+```JavaScript
+function render(page) {
+  function addPerson() {
+    page.people.push({name: "somebody"});
+  }
 
-      return h('div.content',
-        h('h1', 'People'),
-        h('ol',
-          page.people.map(function (person) {
-            return renderPerson(page, person);
-          })
-        ),
-        h('button', {onclick: addPerson}, 'add')
-      );
+  return h('div.content',
+    h('h1', 'People'),
+    h('ol',
+      page.people.map(function (person) {
+        return renderPerson(page, person);
+      })
+    ),
+    h('button', {onclick: addPerson}, 'add')
+  );
+}
+
+function renderPerson(page, person) {
+  function deletePerson() {
+    var i = page.people.indexOf(person);
+
+    if (i >= 0) {
+      page.people.splice(i, 1);
     }
+  }
 
-    function renderPerson(page, person) {
-      function deletePerson() {
-        var i = page.people.indexOf(person);
+  return h('li',
+    h('input', {model: bind(person, 'name')}),
+    h('button', {onclick: deletePerson}, 'delete')
+  )
+}
 
-        if (i >= 0) {
-          page.people.splice(i, 1);
-        }
-      }
-
-      return h('li',
-        h('input', {model: bind(person, 'name')}),
-        h('button', {onclick: deletePerson}, 'delete')
-      )
-    }
-
-    plastiq.attach(document.body, render, {
-      people: [
-        {name: 'Åke'},
-        {name: 'آمر'},
-        {name: '正'}
-      ]
-    });
+plastiq.attach(document.body, render, {
+  people: [
+    {name: 'Åke'},
+    {name: 'آمر'},
+    {name: '正'}
+  ]
+});
+```
 
 ## Animations
 


### PR DESCRIPTION
I tried some of the examples on requirebin and they didn't work (this one: http://requirebin.com/?gist=a51bffb7d591a1e0d2ca but also some requirebin links are missing). I guess this is because the latest version isn't in npm yet?

So I wrote a script to render the examples in readme.md as individual HTML files.