### PR TITLE
refresh the ui from outside dom event handlers?

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,8 @@ exports.attach = function (element, render, model, options) {
   var tree = renderWithRefresh(render, model, refresh);
   var rootNode = createElement(tree);
   element.appendChild(rootNode);
+
+  return { refresh: refresh };
 };
 
 exports.bind = function (obj, prop) {

--- a/test/plastiqSpec.js
+++ b/test/plastiqSpec.js
@@ -15,7 +15,7 @@ describe('plastiq', function () {
   });
 
   function attach(render, model) {
-    plastiq.attach(div, render, model, { requestRender: setTimeout });
+    return plastiq.attach(div, render, model, { requestRender: setTimeout });
   }
 
   function find(selector) {
@@ -148,6 +148,23 @@ describe('plastiq', function () {
         expect(p.attr('class')).to.eql('raw');
         expect(p.attr('style')).to.eql('color: red;');
       });
+    });
+  });
+
+  it('can be refreshed explicitly by the attacher', function() {
+    function render (model) {
+      return h('h1', model.greeting);
+    }
+
+    var model = { greeting: 'bonjour' };
+    var attachment = attach(render, model);
+
+    expect(find('h1').text()).to.equal('bonjour');
+    model.greeting = 'au revoir';
+    expect(find('h1').text()).to.equal('bonjour');
+    attachment.refresh();
+    return retry(function() {
+      expect(find('h1').text()).to.equal('au revoir');
     });
   });
 


### PR DESCRIPTION
Not sure this is a good idea, perhaps I am missing a trick. I was trying to render a loading screen until an async operation completes:

```JavaScript
function render(model) {
  if (model.stuff)
    return h('div.stuff', model.stuff);
  else
    return h('div.loading', 'Loading...');
}

var model = { stuff: null };

loadSomeStuff(function(error, stuff) {
   model.stuff = stuff;
   // tell plastiq the model has changed...
});
```

I also tried attaching an onload handler in render, which seems more consistent but didn't work and I'm not sure that's a good idea either. Am I missing an alternative?