### PR TITLE
onattach

### DIFF
--- a/index.js
+++ b/index.js
@@ -280,6 +280,14 @@ RawHtmlWidget.prototype.update = function (previous, element) {
 RawHtmlWidget.prototype.destroy = function (element) {
 };
 
+exports.html.rawHtml = function (selector, options, html) {
+  if (arguments.length == 2) {
+    return new RawHtmlWidget(selector, undefined, options);
+  } else {
+    return new RawHtmlWidget(selector, options, html);
+  }
+};
+
 function OnAttachWidget(handler) {
   this.handler = handler;
 }
@@ -289,21 +297,12 @@ OnAttachWidget.prototype = {
 
   init: function () {
     this.handler();
-    return null;
+    return document.createTextNode('');
   },
 
   update: function (previous, element) {},
   destroy: function (element) {}
 }
-
-
-exports.html.rawHtml = function (selector, options, html) {
-  if (arguments.length == 2) {
-    return new RawHtmlWidget(selector, undefined, options);
-  } else {
-    return new RawHtmlWidget(selector, options, html);
-  }
-};
 
 function generateClassName(obj) {
   if (typeof(obj) == 'object') {

--- a/index.js
+++ b/index.js
@@ -248,12 +248,28 @@ exports.html = function (selector) {
       bindModel(attributes, childElements, inputType(selector, attributes));
     }
 
+    if (typeof(attributes.onattach) == 'function') {
+      attributes.onattach = new OnAttachHook(attributes.onattach);
+    }
+
     return h.call(undefined, selector, attributes, childElements);
   } else {
     childElements = normaliseChildren(flatten(Array.prototype.slice.call(arguments, 1)));
     return h.call(undefined, selector, childElements);
   }
 };
+
+function OnAttachHook(handler) {
+  this.handler = handler;
+}
+OnAttachHook.prototype = {
+  hook: function() {
+    var handler = this.handler;
+    this.handler = function() {};
+    handler();
+  },
+  unhook: function() {}
+}
 
 function RawHtmlWidget(selector, options, html) {
   this.selector = selector;

--- a/index.js
+++ b/index.js
@@ -249,7 +249,7 @@ exports.html = function (selector) {
     }
 
     if (typeof(attributes.onattach) == 'function') {
-      attributes.onattach = new OnAttachHook(attributes.onattach);
+      childElements.push(new OnAttachWidget(attributes.onattach));
     }
 
     return h.call(undefined, selector, attributes, childElements);
@@ -258,18 +258,6 @@ exports.html = function (selector) {
     return h.call(undefined, selector, childElements);
   }
 };
-
-function OnAttachHook(handler) {
-  this.handler = handler;
-}
-OnAttachHook.prototype = {
-  hook: function() {
-    var handler = this.handler;
-    this.handler = function() {};
-    handler();
-  },
-  unhook: function() {}
-}
 
 function RawHtmlWidget(selector, options, html) {
   this.selector = selector;
@@ -291,6 +279,22 @@ RawHtmlWidget.prototype.update = function (previous, element) {
 
 RawHtmlWidget.prototype.destroy = function (element) {
 };
+
+function OnAttachWidget(handler) {
+  this.handler = handler;
+}
+
+OnAttachWidget.prototype = {
+  type: 'Widget',
+
+  init: function () {
+    this.handler();
+    return null;
+  },
+
+  update: function (previous, element) {},
+  destroy: function (element) {}
+}
 
 
 exports.html.rawHtml = function (selector, options, html) {

--- a/test/plastiqSpec.js
+++ b/test/plastiqSpec.js
@@ -436,6 +436,7 @@ describe('plastiq', function () {
   });
 
   describe('onattach', function() {
+
     it('triggers re-rendering', function() {
 
       function render(model) {
@@ -475,5 +476,38 @@ describe('plastiq', function () {
         });
       });
     });
+
+    context('returning a promise', function() {
+
+      it('triggers re-rendering', function() {
+
+        function writeToLog(model, what) {
+          return function() {
+            return new Promise(function(success) {
+              setTimeout(function() {
+                model.log += what;
+                success();
+              }, 3);
+            })
+          }
+        }
+
+        function render(model) {
+          return h('i', { onattach: writeToLog(model, 'A') },
+            h('i',      { onattach: writeToLog(model, 'B') }),
+            h('h1', model.log)
+          );
+        }
+
+        attach(render, { log: '' });
+
+        expect(find('h1').text()).to.equal('');
+
+        return retry(function() {
+          expect(find('h1').text()).to.equal('BA');
+        });
+      });
+    });
+
   });
 });

--- a/test/plastiqSpec.js
+++ b/test/plastiqSpec.js
@@ -436,22 +436,41 @@ describe('plastiq', function () {
   });
 
   describe('onattach', function() {
-    it('fires once and re-renders', function() {
+    it('triggers re-rendering', function() {
+
       function render(model) {
-        return h('i.x', { onattach: function() { model.log += 'X'; } },
-          h('i.y', { onattach: function() { model.log += 'Y'; } }),
-          h('h1', model.log),
-          h('button', { onclick: function() { model.log += 'Z' }})
+        return h('i', { onattach: function() { model.log += 'X'; } },
+          h('i',      { onattach: function() { model.log += 'Y'; } }),
+          h('h1', model.log)
         );
       }
 
       attach(render, { log: '' });
 
+      expect(find('h1').text()).to.equal('');
+
       return retry(function() {
+        expect(find('h1').text()).to.equal('YX');
+      });
+    });
+
+    it('fires once', function() {
+
+      function render(model) {
+        return h('i', { onattach: function() { model.log += 'X'; } },
+          h('i',      { onattach: function() { model.log += 'Y'; } }),
+          h('button',  { onclick: function() { model.log += 'Z'; } }),
+          h('h1', model.log)
+        );
+      }
+
+      attach(render, { log: '' });
+
+      expect(find('h1').text()).to.equal('');
+      return click('button').then(function() {
         return click('button').then(function() {
-          expect(find('h1').text()).to.equal('XYZ');
-          return click('button').then(function() {
-            expect(find('h1').text()).to.equal('XYZZ');
+          return retry(function() {
+            expect(find('h1').text()).to.equal('YXZZ');
           });
         });
       });

--- a/test/plastiqSpec.js
+++ b/test/plastiqSpec.js
@@ -434,4 +434,27 @@ describe('plastiq', function () {
       });
     });
   });
+
+  describe('onattach', function() {
+    it('fires once and re-renders', function() {
+      function render(model) {
+        return h('i.x', { onattach: function() { model.log += 'X'; } },
+          h('i.y', { onattach: function() { model.log += 'Y'; } }),
+          h('h1', model.log),
+          h('button', { onclick: function() { model.log += 'Z' }})
+        );
+      }
+
+      attach(render, { log: '' });
+
+      return retry(function() {
+        return click('button').then(function() {
+          expect(find('h1').text()).to.equal('XYZ');
+          return click('button').then(function() {
+            expect(find('h1').text()).to.equal('XYZZ');
+          });
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
This adds support for `onattach` handlers, which will fire once after the first render, then trigger a dom refresh.  Ideally it might fire *before* the first render, but the motivation for this is to render a "loading" screen while some async operation completes, so delaying the first render would defeat the purpose.

This implementation uses virtual-dom widgets. I don't think this is exactly what widgets are for, but I'm not sure how else to avoid re-executing the handler when the dom is patched. The answer doesn't appear to be in virtual-dom hooks, not yet anyway.

@refractalize if you're happy with this direction then I'll add some docs.