### PR TITLE
window events

### DIFF
--- a/index.js
+++ b/index.js
@@ -283,91 +283,10 @@ exports.html.rawHtml = function (selector, options, html) {
   }
 };
 
-function WindowWidget(attributes) {
-  this.attributes = attributes;
-
-  var self = this;
-  this.cache = {};
-  Object.keys(this.attributes).forEach(function (key) {
-    self.cache[key] = refreshFunction(self.attributes[key]);
-  });
-}
-
-function applyAttribute(attributes, name, element) {
-  if (/^on/.test(name)) {
-    element.addEventListener(name.substr(2), this[name]);
-  }
-}
-
-WindowWidget.prototype.type = 'Widget';
-WindowWidget.prototype.init = function () {
-  console.log('init', this.attributes);
-
-  applyPropertyDiffs(window, {}, this.attributes, {}, this.cache);
-
-  return document.createTextNode('');
-};
-
-function uniq(array) {
-  var sortedArray = array.slice();
-  sortedArray.sort();
-
-  var last;
-
-  for(var n = 0; n < sortedArray.length;) {
-    var current = sortedArray[n];
-
-    if (last === current) {
-      sortedArray.splice(n, 1);
-    } else {
-      n++;
-    }
-    last = current;
-  }
-
-  return sortedArray;
-}
-
-function applyPropertyDiffs(element, previous, current, previousCache, currentCache) {
-  uniq(Object.keys(previous).concat(Object.keys(current))).forEach(function (key) {
-    if (/^on/.test(key)) {
-      var event = key.slice(2);
-
-      var prev = previous[key];
-      var curr = current[key];
-      var refreshPrev = previousCache[key];
-      var refreshCurr = currentCache[key];
-
-      if (prev !== undefined && curr === undefined) {
-        console.log('removing listener for ', key);
-        element.removeEventListener(event, refreshPrev);
-      } else if (prev !== undefined && curr !== undefined && prev !== curr) {
-        console.log('updating listener for ', key);
-        element.removeEventListener(event, refreshPrev);
-        element.addEventListener(event, refreshCurr);
-      } else if (prev === undefined && curr !== undefined) {
-        console.log('adding listener for ', key);
-        element.addEventListener(event, refreshCurr);
-      } else {
-        console.log('leaving listener for ', key);
-      }
-    }
-  });
-}
-
-WindowWidget.prototype.update = function (previous) {
-  var self = this;
-  console.log('update');
-  applyPropertyDiffs(window, previous.attributes, this.attributes, previous.cache, this.cache);
-};
-
-WindowWidget.prototype.destroy = function () {
-  console.log('destroy');
-  applyPropertyDiffs(window, this.attributes, {}, this.cache, {});
-};
+var windowEvents = require('./windowEvents');
 
 exports.html.window = function (attributes) {
-  return new WindowWidget(attributes);
+  return windowEvents(attributes, refreshFunction);
 };
 
 function generateClassName(obj) {

--- a/index.js
+++ b/index.js
@@ -8,14 +8,12 @@ var globalRefresh;
 function renderWithRefresh(render, model, refresh) {
   var tree;
 
-  console.log('started renderWithRefresh');
   try {
     globalRefresh = refresh;
     tree = render(model);
   } finally {
     globalRefresh = undefined;
   }
-  console.log('finished renderWithRefresh');
 
   return tree;
 }

--- a/index.js
+++ b/index.js
@@ -8,12 +8,14 @@ var globalRefresh;
 function renderWithRefresh(render, model, refresh) {
   var tree;
 
+  console.log('started renderWithRefresh');
   try {
     globalRefresh = refresh;
     tree = render(model);
   } finally {
     globalRefresh = undefined;
   }
+  console.log('finished renderWithRefresh');
 
   return tree;
 }
@@ -279,6 +281,93 @@ exports.html.rawHtml = function (selector, options, html) {
   } else {
     return new RawHtmlWidget(selector, options, html);
   }
+};
+
+function WindowWidget(attributes) {
+  this.attributes = attributes;
+
+  var self = this;
+  this.cache = {};
+  Object.keys(this.attributes).forEach(function (key) {
+    self.cache[key] = refreshFunction(self.attributes[key]);
+  });
+}
+
+function applyAttribute(attributes, name, element) {
+  if (/^on/.test(name)) {
+    element.addEventListener(name.substr(2), this[name]);
+  }
+}
+
+WindowWidget.prototype.type = 'Widget';
+WindowWidget.prototype.init = function () {
+  console.log('init', this.attributes);
+
+  applyPropertyDiffs(window, {}, this.attributes, {}, this.cache);
+
+  return document.createTextNode('');
+};
+
+function uniq(array) {
+  var sortedArray = array.slice();
+  sortedArray.sort();
+
+  var last;
+
+  for(var n = 0; n < sortedArray.length;) {
+    var current = sortedArray[n];
+
+    if (last === current) {
+      sortedArray.splice(n, 1);
+    } else {
+      n++;
+    }
+    last = current;
+  }
+
+  return sortedArray;
+}
+
+function applyPropertyDiffs(element, previous, current, previousCache, currentCache) {
+  uniq(Object.keys(previous).concat(Object.keys(current))).forEach(function (key) {
+    if (/^on/.test(key)) {
+      var event = key.slice(2);
+
+      var prev = previous[key];
+      var curr = current[key];
+      var refreshPrev = previousCache[key];
+      var refreshCurr = currentCache[key];
+
+      if (prev !== undefined && curr === undefined) {
+        console.log('removing listener for ', key);
+        element.removeEventListener(event, refreshPrev);
+      } else if (prev !== undefined && curr !== undefined && prev !== curr) {
+        console.log('updating listener for ', key);
+        element.removeEventListener(event, refreshPrev);
+        element.addEventListener(event, refreshCurr);
+      } else if (prev === undefined && curr !== undefined) {
+        console.log('adding listener for ', key);
+        element.addEventListener(event, refreshCurr);
+      } else {
+        console.log('leaving listener for ', key);
+      }
+    }
+  });
+}
+
+WindowWidget.prototype.update = function (previous) {
+  var self = this;
+  console.log('update');
+  applyPropertyDiffs(window, previous.attributes, this.attributes, previous.cache, this.cache);
+};
+
+WindowWidget.prototype.destroy = function () {
+  console.log('destroy');
+  applyPropertyDiffs(window, this.attributes, {}, this.cache, {});
+};
+
+exports.html.window = function (attributes) {
+  return new WindowWidget(attributes);
 };
 
 function generateClassName(obj) {

--- a/readme.md
+++ b/readme.md
@@ -120,6 +120,21 @@ plastiq.attach(document.body, render, { people: [] });
 
 Play on [requirebin](http://requirebin.com/?gist=729964ebb9c31a2ec698)
 
+## Window Events
+
+You can attach event handlers to `window`, such as `window.onscroll` and `window.onresize`. Return a `h.window()` from your render function passing an object containing the event handlers to attach. When the window vdom is shown, the event handlers are added to `window`, when the window vdom is not shown, the event handlers are removed from `window`.
+
+E.g. to add an `onresize` handler:
+
+```JavaScript
+function render() {
+  return h('div',
+    'width = ' + window.innerWidth + ', height = ' + window.innerHeight,
+    h.window({ onresize: function () {console.log('resizing');} })
+  );
+}
+```
+
 ## Binding the Inputs
 
 This applies to `textarea` and input types `text`, `url`, `date`, `email`, `color`, `range`, `checkbox`, `number`, and a few more obscure ones. Most of them.

--- a/test/plastiqSpec.js
+++ b/test/plastiqSpec.js
@@ -364,6 +364,49 @@ describe('plastiq', function () {
     });
   });
 
+  describe('life cycle', function () {
+    it.only('receives create, update and destroy events', function () {
+      var onclick = function () {
+        console.log('click window');
+      };
+
+      function render(model) {
+        return h('div',
+          model.state < 3
+            ? h.window(
+                {
+                  onclick: function () {
+                    console.log('click window');
+                  }
+                }
+              )
+            : undefined,
+          h('button', {onclick: function () { model.state++; }}, 'haha')
+        );
+      }
+
+      attach(render, {state: 0});
+
+      function wait(n) {
+        return new Promise(function (result) {
+          setTimeout(result, n);
+        });
+      }
+
+      return click('button').then(function () {
+        return wait(10).then(function () {
+          return click('button').then(function () {
+            return wait(10).then(function () {
+              return click('button').then(function () {
+                return wait(10);
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+
   describe('animations', function () {
     it('can render several frames of an animation', function () {
       this.timeout(10000);

--- a/test/plastiqSpec.js
+++ b/test/plastiqSpec.js
@@ -383,7 +383,7 @@ describe('plastiq', function () {
   });
 
   describe('life cycle', function () {
-    it.only('receives create, update and destroy events', function () {
+    it('receives create, update and destroy events', function () {
       function render(model) {
         return h('div',
           model.active

--- a/windowEvents.js
+++ b/windowEvents.js
@@ -16,8 +16,6 @@ function applyAttribute(attributes, name, element) {
 
 WindowWidget.prototype.type = 'Widget';
 WindowWidget.prototype.init = function () {
-  console.log('init', this.attributes);
-
   applyPropertyDiffs(window, {}, this.attributes, {}, this.cache);
 
   return document.createTextNode('');
@@ -54,17 +52,12 @@ function applyPropertyDiffs(element, previous, current, previousCache, currentCa
       var refreshCurr = currentCache[key];
 
       if (prev !== undefined && curr === undefined) {
-        console.log('removing listener for ', key);
         element.removeEventListener(event, refreshPrev);
       } else if (prev !== undefined && curr !== undefined && prev !== curr) {
-        console.log('updating listener for ', key);
         element.removeEventListener(event, refreshPrev);
         element.addEventListener(event, refreshCurr);
       } else if (prev === undefined && curr !== undefined) {
-        console.log('adding listener for ', key);
         element.addEventListener(event, refreshCurr);
-      } else {
-        console.log('leaving listener for ', key);
       }
     }
   });
@@ -72,12 +65,10 @@ function applyPropertyDiffs(element, previous, current, previousCache, currentCa
 
 WindowWidget.prototype.update = function (previous) {
   var self = this;
-  console.log('update');
   applyPropertyDiffs(window, previous.attributes, this.attributes, previous.cache, this.cache);
 };
 
 WindowWidget.prototype.destroy = function () {
-  console.log('destroy');
   applyPropertyDiffs(window, this.attributes, {}, this.cache, {});
 };
 

--- a/windowEvents.js
+++ b/windowEvents.js
@@ -1,0 +1,86 @@
+function WindowWidget(attributes, refreshFunction) {
+  this.attributes = attributes;
+
+  var self = this;
+  this.cache = {};
+  Object.keys(this.attributes).forEach(function (key) {
+    self.cache[key] = refreshFunction(self.attributes[key]);
+  });
+}
+
+function applyAttribute(attributes, name, element) {
+  if (/^on/.test(name)) {
+    element.addEventListener(name.substr(2), this[name]);
+  }
+}
+
+WindowWidget.prototype.type = 'Widget';
+WindowWidget.prototype.init = function () {
+  console.log('init', this.attributes);
+
+  applyPropertyDiffs(window, {}, this.attributes, {}, this.cache);
+
+  return document.createTextNode('');
+};
+
+function uniq(array) {
+  var sortedArray = array.slice();
+  sortedArray.sort();
+
+  var last;
+
+  for(var n = 0; n < sortedArray.length;) {
+    var current = sortedArray[n];
+
+    if (last === current) {
+      sortedArray.splice(n, 1);
+    } else {
+      n++;
+    }
+    last = current;
+  }
+
+  return sortedArray;
+}
+
+function applyPropertyDiffs(element, previous, current, previousCache, currentCache) {
+  uniq(Object.keys(previous).concat(Object.keys(current))).forEach(function (key) {
+    if (/^on/.test(key)) {
+      var event = key.slice(2);
+
+      var prev = previous[key];
+      var curr = current[key];
+      var refreshPrev = previousCache[key];
+      var refreshCurr = currentCache[key];
+
+      if (prev !== undefined && curr === undefined) {
+        console.log('removing listener for ', key);
+        element.removeEventListener(event, refreshPrev);
+      } else if (prev !== undefined && curr !== undefined && prev !== curr) {
+        console.log('updating listener for ', key);
+        element.removeEventListener(event, refreshPrev);
+        element.addEventListener(event, refreshCurr);
+      } else if (prev === undefined && curr !== undefined) {
+        console.log('adding listener for ', key);
+        element.addEventListener(event, refreshCurr);
+      } else {
+        console.log('leaving listener for ', key);
+      }
+    }
+  });
+}
+
+WindowWidget.prototype.update = function (previous) {
+  var self = this;
+  console.log('update');
+  applyPropertyDiffs(window, previous.attributes, this.attributes, previous.cache, this.cache);
+};
+
+WindowWidget.prototype.destroy = function () {
+  console.log('destroy');
+  applyPropertyDiffs(window, this.attributes, {}, this.cache, {});
+};
+
+module.exports = function (attributes, refreshFunction) {
+  return new WindowWidget(attributes, refreshFunction);
+};


### PR DESCRIPTION
This is a way to attach event handlers to `window`, such as `window.onscroll` and `window.onresize`. We have an API call `h.window()` that takes an object containing the event handlers to attach. These event handlers use `addEventListener` and `removeEventListener` as the view tree goes in and out of existence.

E.g. to add an `onresize` handler:

```JavaScript
function render() {
  return h('div',
    'width = ' + window.innerWidth + ', height = ' + window.innerHeight,
    h.window({ onresize: function () {console.log('resizing');} })
  );
}
```

The result of `h.window()` is to be added to the output of the view, even though it renders nothing. The changes are made to the `window` object.