### PR TITLE
validate package.json

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,7 +15,7 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      'test/**/*Spec.js'
+      'test/karma/**/*Spec.js'
     ],
 
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "watchify": "^2.2.1"
   },
   "scripts": {
-    "test": "karma start --single-run",
+    "test": "mocha test/node/*Spec.js && karma start --single-run",
+    "mocha": "mocha test/node/*Spec.js",
+    "karma": "karma start --single-run",
     "prepublish": "browserify browser.js | uglifyjs > plastiq.js"
   },
   "keywords": [
@@ -39,7 +41,8 @@
   "license": "MIT",
   "files": [
     "index.js",
-    "plastiq.js"
+    "plastiq.js",
+    "windowEvents.js"
   ],
   "repository": {
     "type": "git",

--- a/test/karma/plastiqSpec.js
+++ b/test/karma/plastiqSpec.js
@@ -1,5 +1,5 @@
 var $ = require('jquery');
-var plastiq = require('..');
+var plastiq = require('../..');
 var h = plastiq.html;
 var bind = plastiq.bind;
 var expect = require('chai').expect;

--- a/test/node/packageSpec.js
+++ b/test/node/packageSpec.js
@@ -1,0 +1,29 @@
+var fs = require('fs');
+var path = require('path');
+var expect = require('chai').expect;
+var root = path.resolve(__dirname, '..', '..');
+var temp = root + '/package-spec-temp/';
+var packageJSON = require('../../package.json');
+
+describe('package', function() {
+
+  before(function() {
+    fs.mkdirSync(temp);
+    packageJSON.files.forEach(function(file) {
+      fs.writeFileSync(temp + file, fs.readFileSync(file));
+    });
+  });
+
+  after(function() {
+    packageJSON.files.forEach(function(file) {
+      fs.unlinkSync(temp + file);
+    });
+    fs.rmdirSync(temp);
+  });
+
+  it('returns a module', function() {
+    var plastiq = require(temp + packageJSON.main);
+    expect(plastiq.html).to.be.a('Function');
+  });
+
+});


### PR DESCRIPTION
Dunno if this is silly but I couldn't use github master as an npm dependency because a file was missing from package.json. I've fixed that in master already.

Perhaps we don't need to mention each file in package.json, or maybe there's an easier way to validate the list?