### PR TITLE
rawHtml only updates dom when HTML changes

### DIFF
--- a/rawHtml.js
+++ b/rawHtml.js
@@ -16,7 +16,9 @@ RawHtmlWidget.prototype.init = function () {
 };
 
 RawHtmlWidget.prototype.update = function (previous, element) {
-  element.parentNode.replaceChild(this.init(), element);
+  if (this.html != previous.html) {
+    element.parentNode.replaceChild(this.init(), element);
+  }
 };
 
 RawHtmlWidget.prototype.destroy = function (element) {

--- a/test/karma/plastiqSpec.js
+++ b/test/karma/plastiqSpec.js
@@ -191,12 +191,13 @@ describe('plastiq', function () {
         expect(p.attr('style')).to.eql('color: red;');
       });
 
-      it('only updates the dom when the HTML changes', function() {
+      it('updates the dom when the HTML changes', function() {
         function render(model) {
           return h('div',
             h.rawHtml('p.raw', model.html),
             h('p.x', model.x),
-            h('button', {onclick: function () { model.x = 'zzz'; }})
+            h('button.one', {onclick: function () { model.x = 'zzz'; }}),
+            h('button.two', {onclick: function () { model.html = 'Nice <b>HTML</b>'; }})
           );
         }
 
@@ -206,11 +207,16 @@ describe('plastiq', function () {
 
         var b = find('p.raw b')[0];
 
-        return click('button').then(function () {
+        return click('button.one').then(function () {
           return retry(function() {
             expect(find('p.x').html()).to.equal('zzz');
           }).then(function() {
             expect(find('p.raw b')[0]).to.equal(b);
+            return click('button.two').then(function () {
+              return retry(function() {
+                expect(find('p.raw b')[0]).not.to.equal(b);
+              });
+            });
           })
         });
       });

--- a/test/karma/plastiqSpec.js
+++ b/test/karma/plastiqSpec.js
@@ -190,6 +190,30 @@ describe('plastiq', function () {
         expect(p.attr('class')).to.eql('raw');
         expect(p.attr('style')).to.eql('color: red;');
       });
+
+      it('only updates the dom when the HTML changes', function() {
+        function render(model) {
+          return h('div',
+            h.rawHtml('p.raw', model.html),
+            h('p.x', model.x),
+            h('button', {onclick: function () { model.x = 'zzz'; }})
+          );
+        }
+
+        attach(render, {html: 'Naughty <b>HTML</b>', x: 'yyy'});
+
+        expect(find('p.raw').html()).to.equal('Naughty <b>HTML</b>');
+
+        var b = find('p.raw b')[0];
+
+        return click('button').then(function () {
+          return retry(function() {
+            expect(find('p.x').html()).to.equal('zzz');
+          }).then(function() {
+            expect(find('p.raw b')[0]).to.equal(b);
+          })
+        });
+      });
     });
   });
 


### PR DESCRIPTION
This prevents re-rendering the DOM nodes created by `rawHtml` until necessary, which seems like the right thing to do most of the time. Do you think it should be optional?