### PR TITLE
move .attach() to plastiq.html?

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var rendering = require('./rendering');
 
 exports.html = rendering.html;
-exports.attach = rendering.attach;
+exports.html.attach = rendering.attach;
 
 exports.bind = require('./bind');
 

--- a/readme.md
+++ b/readme.md
@@ -28,8 +28,7 @@ Then
 # An Example
 
 ```JavaScript
-var plastiq = require('plastiq');
-var h = plastiq.html;
+var h = require('plastiq').html;
 
 function render(model) {
   return h('div',
@@ -39,7 +38,7 @@ function render(model) {
   );
 }
 
-plastiq.attach(document.body, render, {name: ''});
+h.attach(document.body, render, {name: ''});
 ```
 
 Try it on [requirebin](http://requirebin.com/?gist=9890d270f676e9bb2681).
@@ -122,7 +121,7 @@ function render(model) {
   );
 }
 
-plastiq.attach(document.body, render, { people: [] });
+h.attach(document.body, render, { people: [] });
 ```
 
 Try it on [requirebin](http://requirebin.com/?gist=82bf7e63cbb4072b71f0)
@@ -159,7 +158,7 @@ function render(model) {
   );
 }
 
-plastiq.attach(document.body, render, { name: '' });
+h.attach(document.body, render, { name: '' });
 ```
 
 Try it on [requirebin](http://requirebin.com/?gist=9890d270f676e9bb2681).
@@ -190,7 +189,7 @@ function render(model) {
   );
 }
 
-plastiq.attach(document.body, render, { colour: blue });
+h.attach(document.body, render, { colour: blue });
 ```
 
 Try it on [requirebin](http://requirebin.com/?gist=af4b00af80d6aea3d3fe).
@@ -214,7 +213,7 @@ function render(model) {
   );
 }
 
-plastiq.attach(document.body, render, { colour: blue });
+h.attach(document.body, render, { colour: blue });
 ```
 
 Try it on [requirebin](http://requirebin.com/?gist=0c9b0eeb62e9b1f2089b).
@@ -250,7 +249,7 @@ function render(model) {
   );
 }
 
-plastiq.attach(document.body, render, {
+h.attach(document.body, render, {
   filename: '(no file selected)',
   contents: ''
 });
@@ -305,7 +304,7 @@ function render(model) {
   );
 }
 
-plastiq.attach(document.body, render, {});
+h.attach(document.body, render, {});
 ```
 
 Try it on [requirebin](http://requirebin.com/?gist=7c08489a84b0766651a9).
@@ -330,7 +329,7 @@ function render(model) {
   );
 }
 
-plastiq.attach(document.body, render, {counter: 0});
+h.attach(document.body, render, {counter: 0});
 ```
 
 Try it on [requirebin](http://requirebin.com/?gist=afb1a6123309267b2d5a).
@@ -371,7 +370,7 @@ function renderPerson(model, person) {
   )
 }
 
-plastiq.attach(document.body, render, {
+h.attach(document.body, render, {
   people: [
     {name: 'Åke'},
     {name: 'آمر'},
@@ -410,7 +409,7 @@ function render(model) {
   );
 }
 
-plastiq.attach(document.body, render, {
+h.attach(document.body, render, {
   animals: [
     {
       name: 'Harry',
@@ -452,7 +451,7 @@ Try it on [requirebin](http://requirebin.com/?gist=41d56a087b5f9fa7d062).
 
 An event handler can return a function that is passed a `render` function that can be called to request a re-render of the page when the model has been updated. This can be used to create animations that change the model and re-render the page.
 
-Notice that the `render()` function only *requests* a re-render, which will happen at some point in the future but not immediately. Several calls to `render()` may only result in one actual render. See the `requestRender` option in [`plastiq.attach`](#plastiqattach) below.
+Notice that the `render()` function only *requests* a re-render, which will happen at some point in the future but not immediately. Several calls to `render()` may only result in one actual render. See the `requestRender` option in [`plastiq.html.attach`](#plastiqhtmlattach) below.
 
 ```JavaScript
 function render(model) {
@@ -471,7 +470,7 @@ function render(model) {
   );
 }
 
-plastiq.attach(document.body, render, { n: 0 });
+h.attach(document.body, render, { n: 0 });
 ```
 
 Play on [requirebin](http://requirebin.com/?gist=641b92c81d69300a4277)
@@ -495,7 +494,7 @@ function render(model) {
   });
 }
 
-plastiq.attach(document.body, render, {
+h.attach(document.body, render, {
   longRunningOperation: new Promise(function (fulfill) {
     setTimeout(function () {
       fulfill('bananas');
@@ -518,7 +517,7 @@ function render(model) {
   );
 }
 
-plastiq.attach(document.body, render, {
+h.attach(document.body, render, {
   animation: function (refresh) {
     var self = this;
 
@@ -597,7 +596,7 @@ If the event handler returns a function, then that function will be called with 
 **Careful of script injection attacks!** Make sure the HTML is trusted or free of `<script>` tags.
 
 ```JavaScript
-var vdomFragment = plastiq.html.rawHtml(selector, [attributes], html);
+var vdomFragment = h.rawHtml(selector, [attributes], html);
 ```
 
 * `selector` - (almost) any selector, containing element names, classes and ids. E.g. `tag.class#id`
@@ -607,7 +606,7 @@ var vdomFragment = plastiq.html.rawHtml(selector, [attributes], html);
 ## Components
 
 ```JavaScript
-var component = plastiq.html.component([eventHandlers], vdomFragment | renderFunction);
+var component = h.component([eventHandlers], vdomFragment | renderFunction);
 ```
 
 * `eventHandlers` - object containing:
@@ -623,7 +622,7 @@ var component = plastiq.html.component([eventHandlers], vdomFragment | renderFun
 ## Attaching to the DOM
 
 ```JavaScript
-plastiq.attach(element, render, model, [options]);
+h.attach(element, render, model, [options]);
 ```
 
 * `element` - any HTML element. The view is attached via `element.appendChild(view)`

--- a/test/karma/plastiqSpec.js
+++ b/test/karma/plastiqSpec.js
@@ -1,6 +1,5 @@
 var $ = require('jquery');
-var plastiq = require('../..');
-var h = plastiq.html;
+var h = require('../..').html;
 var expect = require('chai').expect;
 var retry = require('trytryagain');
 require('jquery-sendkeys');
@@ -14,7 +13,7 @@ describe('plastiq', function () {
   });
 
   function attach(render, model) {
-    plastiq.attach(div, render, model, { requestRender: setTimeout });
+    h.attach(div, render, model, { requestRender: setTimeout });
   }
 
   function find(selector) {


### PR DESCRIPTION
Not sure I actually prefer this :smile_cat: but I noticed that if `plastiq.bind` is deprecated then everything except `plastiq.attach()` is accessible via `plastiq.html`, so what's the point in:
```JavaScript
var plastiq = require('plastiq');
var h = plastiq.html;
...
plastiq.attach(...);
```
...vs:
```JavaScript
var h = require('plastiq').html;
...
h.attach(...);
```
...or otherwise:
```JavaScript
var h = require('plastiq/html');
...
h.attach(...);
```
?