### PR TITLE
fix and test node require('plastiq')

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "chai": "^1.10.0",
     "jquery": "^2.1.3",
     "jquery-sendkeys": "^1.0.2",
+    "jsdom": "^3.1.1",
     "karma-browserify": "^2.0.0",
     "karma-chrome-launcher": "^0.1.7",
     "karma-cli": "0.0.4",
@@ -25,7 +26,9 @@
     "watchify": "^2.2.1"
   },
   "scripts": {
-    "test": "karma start --single-run",
+    "test": "npm run karma && npm run mocha",
+    "karma": "karma start --single-run",
+    "mocha": "mocha test/mocha/*Spec.js",
     "prepublish": "browserify browser.js > plastiq.js && uglifyjs plastiq.js > plastiq.min.js"
   },
   "keywords": [

--- a/rendering.js
+++ b/rendering.js
@@ -38,7 +38,8 @@ exports.append = function (element, render, model, options) {
 };
 
 function start(render, model, options, attachToDom) {
-  var requestRender = (options && options.requestRender) || window.requestAnimationFrame || setTimeout;
+  var win = (options && options.window) || window;
+  var requestRender = (options && options.requestRender) || win.requestAnimationFrame || win.setTimeout;
   var requested = false;
 
   function refresh() {

--- a/router.js
+++ b/router.js
@@ -1,4 +1,4 @@
-var plastiq = require('.');
+var plastiq = require('./');
 var rendering = require('./rendering');
 var routism = require('routism');
 

--- a/test/mocha/domSpec.js
+++ b/test/mocha/domSpec.js
@@ -1,0 +1,29 @@
+var plastiq = require('../..');
+var jsdom = require('jsdom');
+var expect = require('chai').expect;
+
+describe('plastiq', function() {
+
+  it('renders elements in a dom', function(done) {
+    jsdom.env(
+      '',
+      [],
+      function (errors, window) {
+        var render = function(model) {
+          return plastiq.html('p', 'hello');
+        }
+        function requestRender(render) {
+          render();
+        }
+
+        plastiq.append(window.document.body, render, {}, {
+          window: window,
+          requestRender: requestRender
+        });
+        expect(window.document.body.childNodes[0].tagName).to.equal('P');
+        done();
+      }
+    );
+  });
+
+});


### PR DESCRIPTION
A one character change with a lot of fluff around it :)

`require('plastiq')` was failing under node, for me (see below) because apparently `require('.')` doesn't work whereas `require('./')` does.

This PR fixes that and adds a mocha test. Not sure if we really need mocha tests yet because of this, wdyt?

```
➜   npm install plastiq
plastiq@1.9.2 node_modules/plastiq
├── routism@0.0.4
└── virtual-dom@1.3.0 (browser-split@0.0.1, x-is-string@0.1.0, x-is-array@0.1.0, next-tick@0.2.2, is-object@1.0.1, ev-store@7.0.0, global@4.3.0, error@4.4.0)
➜  echo 'require("plastiq")' > test.js
➜  node test.js

module.js:340
    throw err;
          ^
Error: Cannot find module '.'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/Users/joshchisholm/projects/plastiq-node-require-bug/node_modules/plastiq/router.js:1:77)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
```