### PR TITLE
Ignore promises and animations in "detached" rendering

### DIFF
--- a/animation.js
+++ b/animation.js
@@ -2,7 +2,9 @@ var rendering = require('./rendering');
 
 function AnimationWidget(fn) {
   this.fn = fn;
-  this.refresh = rendering.currentRender.refresh;
+  if (rendering.currentRender) {
+    this.refresh = rendering.currentRender.refresh;
+  }
 }
 
 AnimationWidget.prototype.type = 'Widget';
@@ -11,6 +13,9 @@ AnimationWidget.prototype.init = function () {
   this.fn(this.refresh);
   return document.createTextNode('');
 };
+
+AnimationWidget.prototype.refresh = function () {
+}
 
 AnimationWidget.prototype.update = function () {
 };

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "virtual-dom": "^1.1.0"
   },
   "devDependencies": {
+    "bluebird": "^2.9.12",
     "browserify": "^8.1.0",
     "chai": "^1.10.0",
     "jquery": "^2.1.3",

--- a/promise.js
+++ b/promise.js
@@ -6,7 +6,9 @@ var domComponent = require('./domComponent');
 function PromiseWidget(promise, handlers) {
   this.promise = promise;
   this.handlers = handlers;
-  this.refresh = rendering.currentRender.refresh;
+  if (rendering.currentRender) {
+    this.refresh = rendering.currentRender.refresh;
+  }
   this.component = domComponent();
 }
 
@@ -44,6 +46,9 @@ PromiseWidget.prototype.init = function () {
     return this.component.create(runPromiseHandler(this.handlers, this.handlers.fulfilled, this.value));
   }
 };
+
+PromiseWidget.prototype.refresh = function () {
+}
 
 PromiseWidget.prototype.update = function (previous) {
   if (previous.promise === this.promise && (previous.rejected || previous.fulfilled)) {

--- a/test/mocha/detachedRenderingSpec.js
+++ b/test/mocha/detachedRenderingSpec.js
@@ -1,13 +1,15 @@
 var plastiq = require('../..');
+var h = plastiq.html;
+
 var stringify = require('virtual-dom-stringify');
 var expect = require('chai').expect;
+var Promise = require('bluebird').Promise;
 
 describe('plastiq', function() {
 
-  describe('.html()', function() {
+  describe('.html(), detached from a real DOM', function() {
 
     it('creates a virtual dom with event handlers', function() {
-      var h = plastiq.html;
       var model = { counter: 0 };
       var vdom = h('.outer',
         h('.inner', {
@@ -25,12 +27,27 @@ describe('plastiq', function() {
     });
 
     it('creates a virtual dom with animations', function() {
-      var h = plastiq.html;
       var animation = function (refresh) {
         refresh();
       }
       var vdom = h('.outer',
         h('.inner', h.animation(animation))
+      );
+      var html = stringify(vdom);
+      expect(html).to.equal('<div class="outer"><div class="inner"></div></div>');
+    });
+
+    it('creates a virtual dom with promises', function() {
+      var p = new Promise(function (fulfill) {
+        fulfill('value');
+      });
+
+      var vdom = h('.outer',
+        h('.inner', h.promise({
+          pending: 'hello',
+          fulfilled: 'goodbye',
+          rejected: 'oh noes'
+        }))
       );
       var html = stringify(vdom);
       expect(html).to.equal('<div class="outer"><div class="inner"></div></div>');

--- a/test/mocha/stringifySpec.js
+++ b/test/mocha/stringifySpec.js
@@ -24,6 +24,18 @@ describe('plastiq', function() {
       expect(model.counter).to.equal(2);
     });
 
+    it('creates a virtual dom with animations', function() {
+      var h = plastiq.html;
+      var animation = function (refresh) {
+        refresh();
+      }
+      var vdom = h('.outer',
+        h('.inner', h.animation(animation))
+      );
+      var html = stringify(vdom);
+      expect(html).to.equal('<div class="outer"><div class="inner"></div></div>');
+    });
+
   });
 
 });


### PR DESCRIPTION
Stops animations and promises from breaking server-side rendering.

Since the animations and promises are not actually executed, this means they are effectively ignored when you render the vdom fragment to a string. This probably isn't quite what you want in server-side rendering, but it's better than broken.

It seems maybe we need something that simulates `plastiq.append` on the server-side?

For example, if I have an animation somewhere in my application's `render(model)`, I probably want to render the first frame of that animation on the server-side. If I have a promise, I probably want to render the `pending` vdom fragment, and so on... 