### PR TITLE
model sync

### DIFF
--- a/sync.js
+++ b/sync.js
@@ -1,0 +1,67 @@
+var rendering = require('./rendering');
+var bind = require('./binding');
+var $ = require('jquery');
+
+module.exports.get = function(options, url) {
+  var binding = rendering.binding(options.binding);
+  var model = binding.get();
+
+  if (!model || model.url !== url) {
+    if (model && model.request) {
+      console.log('aborting', model.url);
+      model.request.abort();
+    }
+
+    var request = $.get(url);
+
+    request.then(function (response) {
+      var latest = binding.get();
+
+      if (latest.slowTimeout) {
+        clearTimeout(latest.slowTimeout);
+      }
+
+      if (latest.url == url) {
+        binding.set({
+          url: url,
+          value: response
+        });
+      } else {
+        console.log('ignoring', url);
+      }
+    }, function (error) {
+      var latest = binding.get();
+
+      if (latest.slowTimeout) {
+        clearTimeout(latest.slowTimeout);
+      }
+
+      if (latest.url == url) {
+        binding.set({
+          url: url,
+          error: error.responseText
+        });
+      }
+    });
+
+    var slow = setTimeout(function () {
+      if (binding.get().slowTimeout == slow) {
+        binding.set({
+          request: request,
+          url: url,
+          value: model && model.value,
+          loading: true,
+          slow: true
+        });
+      }
+    }, 140);
+
+    binding.set({
+      request: request,
+      url: url,
+      value: model && model.value,
+      loading: true,
+      slowTimeout: slow
+    });
+  }
+};


### PR DESCRIPTION
I'm experimenting with the idea that the model synchronises with the server during the render cycle.

In the render, we use

    sync.get({binding: [model, 'searchResults']}, '/search?query=' + model.search);

To bind the search results to the model, which are obtained through a HTTP GET. We only issue a new GET when the URL changes (via the search query).

The `searchResults` is an object that contains:

* `value` - the resource if loaded successfully
* `loading: true` - if the resource is still loading
* `error` - if there was an error loading the resource

We have both `loading = true` and the previous `value` if we're reloading, so the page doesn't flash when loading new resources.

There seems to be something wrong about putting the model sync inside the `render`. I imagined putting inside another `sync` function, but then you'd have a parallel hierarchy of rendering and syncing for a page, not great. Putting it inside `render` is almost always what you want, even if `render` and `sync` are kind of different activities. For example, when would you want to sync _without_ rendering? I can't really think of many...

The full example:

    var plastiq = require('..');
    var sync = require('../sync');
    var h = plastiq.html;

    function render(model) {
      sync.get({binding: [model, 'searchResults']}, '/search?query=' + model.search);

      return h('div',
        h('label', 'search'),
        h('input', {type: 'text', binding: [model, 'search']}),
        h('div',
          h('h2', 'search results for ' + model.search),
          model.searchResults.value
          ? h('ol',
              model.searchResults.value.map(function (result) {
                return h('li', result);
              })
            )
          : model.searchResults.loading
            ? h('span', 'loading')
            : model.searchResults.error
              ? h('span', 'error', model.searchResults.error)
              : undefined
        )
      );
    }

    var model = {search: ''};

    plastiq.append(document.body, render, model);
