### PR TITLE
conversion bindings

### DIFF
--- a/component.js
+++ b/component.js
@@ -6,7 +6,9 @@ function ComponentWidget(state, vdom) {
   this.state = state;
   this.key = state.key;
   if (typeof vdom === 'function') {
-    this.render = vdom;
+    this.render = function () {
+      return vdom.apply(this.state, arguments);
+    };
     this.canRefresh = true;
   } else {
     vdom = vdom || new VText('');
@@ -22,6 +24,10 @@ ComponentWidget.prototype.type = 'Widget';
 
 ComponentWidget.prototype.init = function () {
   var self = this;
+
+  if (self.state.onbeforeadd) {
+    self.state.onbeforeadd();
+  }
 
   var vdom = this.render(this);
   if (vdom instanceof Array) {

--- a/component.js
+++ b/component.js
@@ -61,9 +61,11 @@ ComponentWidget.prototype.update = function (previous) {
   this.component = previous.component;
   
   if (previous.state && this.state) {
-    Object.keys(this.state).forEach(function (key) {
+    var keys = Object.keys(this.state);
+    for(var n = 0; n < keys.length; n++) {
+      var key = keys[n];
       previous.state[key] = self.state[key];
-    });
+    }
     this.state = previous.state;
   }
 

--- a/meta.js
+++ b/meta.js
@@ -1,0 +1,16 @@
+module.exports = function (model, property) {
+  var plastiqMeta = model._plastiqMeta;
+
+  if (!plastiqMeta) {
+    plastiqMeta = {};
+    Object.defineProperty(model, '_plastiqMeta', {value: plastiqMeta});
+  }
+
+  var meta = plastiqMeta[property];
+
+  if (!meta) {
+    meta = plastiqMeta[property] = {};
+  }
+
+  return meta;
+};

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "virtual-dom": "2.0.1"
   },
   "devDependencies": {
+    "benchmark": "1.0.0",
     "bluebird": "^2.9.12",
     "browserify": "9.0.3",
     "chai": "2.0.0",

--- a/readme.md
+++ b/readme.md
@@ -107,13 +107,22 @@ h('span', {attributes: {'my-html-attribute': 'stuff'}}, 'name: ', model.name);
 Plastiq (or rather [virtual-dom](https://github.com/Matt-Esch/virtual-dom)) is not clever enough to be able to compare lists of elements. For example, say you render the following:
 
 ```js
-h('ul', h('li', 'one'), h('li', 'two'), h('li', 'three'))
+h('ul',
+  h('li', 'one'),
+  h('li', 'two'),
+  h('li', 'three')
+)
 ```
 
 And then, followed by:
 
 ```js
-h('ul', h('li', 'zero'), h('li', 'one'), h('li', 'two'), h('li', 'three'))
+h('ul',
+  h('li', 'zero'),
+  h('li', 'one'),
+  h('li', 'two'),
+  h('li', 'three')
+)
 ```
 
 The lists will be compared like this, and lots of work will be done to change the DOM:
@@ -649,11 +658,11 @@ var binding = plastiq.html.binding(binding, options);
 
 ### Performance
 
-Plastiq is usually very fast. It's based on [virtual-dom](https://github.com/Matt-Esch/virtual-dom) which has excellent performance, even making React look slow. See [these benchmarks](http://vdom-benchmark.github.io/vdom-benchmark/). However, if you have very large and interactive pages there are several strategies you can employ to speed things up.
+Plastiq is usually very fast. It's based on [virtual-dom](https://github.com/Matt-Esch/virtual-dom) which has excellent performance, several times faster than React. See [these benchmarks](http://vdom-benchmark.github.io/vdom-benchmark/). However, if you have very large and interactive pages there are several strategies you can employ to speed things up.
 
 * Consider only rendering a part of the page on certain events. For this, you can use a [component](#components) for the portion of the page you want to refresh, then return that component from the event handler.
 * Consider using [key](#keys) attributes for large dynamic lists of elements. Key attributes allow the diffing engine to spot differences inside lists of elements in some cases massively reducing the amount of DOM changes between renders.
-* For form inputs, consider using `plastiq.html.binding()` to not refresh, or only refresh a component.
+* For form inputs with bindings, especially text inputs that can refresh the page on each keypress, consider using `plastiq.html.binding()` to not refresh, or only refresh a component.
 
 # API
 

--- a/readme.md
+++ b/readme.md
@@ -362,21 +362,24 @@ function render(model) {
     model.show
       ? h.component(
           {
-            onadd: function (element) {
-              // element is the <div>component contents</div>
-              // you may want to add jQuery plugins here
-
+            onbeforeadd: function () {
               // you can store state in `this`, and it will
               // be present in subsequent event handlers
               // in fact, the `this` is the same object
               // for each event handler, across all view refreshes
               this.someProperty = 'some value';
+            },
 
+            onadd: function (element) {
+              // element is the <div>component contents</div>
+              // you may want to add jQuery plugins here
               console.log('added: ', this.someProperty);
             },
+
             onupdate: function (element) {
               console.log('updated: ', this.someProperty);
             },
+
             onremove: function (element) {
               console.log('removed: ', this.someProperty);
             }
@@ -708,6 +711,7 @@ var component = plastiq.html.component([eventHandlers], vdomFragment | renderFun
 ```
 
 * `eventHandlers` - object containing:
+  * `function onbeforeadd()` - invoked before the component is rendered for the first time, before `renderFunction`. This is a good place to setup state for the component.
   * `function onadd(element)` - invoked after the component has been rendered for the first time, the `element` being the top-most DOM element in the component.
   * `function onupdate(element)` - invoked after the component has been re-rendered, `element` being the top-most DOM element in the component.
   * `function onremove(element)` - invoked after the component has been removed from the DOM, `element` being the top-most DOM element in the component.

--- a/readme.md
+++ b/readme.md
@@ -634,6 +634,18 @@ var refreshHandler = h.refreshify(handler, [options]);
   * `true` - (the default) `refreshHandler` will refresh on return, and on promise fulfil if it returns a promise.
   * `false` - `refreshHandler` will be just `handler` so no refresh will happen if you call it.
   * `'promise'` - `refreshHandler` will only refresh if it returns a promise and only after the promise is fulfilled.
+* `options.component` - only refresh this [component](#components)
+
+### Binding
+
+You can customise how bindings refresh the page by using `plastiq.html.binding()`.
+
+```js
+var binding = plastiq.html.binding(binding, options);
+```
+
+* `binding` - an array [model, 'property'], or a binding object {get(), set(value)}.
+* `options` - options that are passed directly to [refreshify](#refreshify).
 
 ### Performance
 
@@ -641,6 +653,7 @@ Plastiq is usually very fast. It's based on [virtual-dom](https://github.com/Mat
 
 * Consider only rendering a part of the page on certain events. For this, you can use a [component](#components) for the portion of the page you want to refresh, then return that component from the event handler.
 * Consider using [key](#keys) attributes for large dynamic lists of elements. Key attributes allow the diffing engine to spot differences inside lists of elements in some cases massively reducing the amount of DOM changes between renders.
+* For form inputs, consider using `plastiq.html.binding()` to not refresh, or only refresh a component.
 
 # API
 

--- a/rendering.js
+++ b/rendering.js
@@ -401,7 +401,56 @@ function makeBinding(b, options) {
   return binding;
 };
 
-function bindingObject(obj, prop, options) {
+function Binding(model, property) {
+  this.model = model;
+  this.property = property;
+}
+
+Binding.prototype.get = function () {
+  return this.model[this.property];
+};
+
+Binding.prototype.set = function (value) {
+  this.model[this.property] = value;
+};
+
+Binding.prototype.meta: function () {
+  var plastiqMeta = this.model._plastiqMeta;
+
+  if (!plastiqMeta) {
+    plastiqMeta = {};
+    Object.defineProperty(this.model, '_plastiqMeta', {value: plastiqMeta});
+  }
+
+  var meta = plastiqMeta[this.property];
+
+  if (!meta) {
+    meta = plastiqMeta[this.property] = {};
+  }
+
+  return meta;
+};
+
+function ConversionBinding(model, property, converter) {
+  this.model = model;
+  this.property = property;
+  this.converter = converter;
+}
+
+ConversionBinding.prototype = new Binding();
+
+ConversionBinding.prototype.get = function() {
+  return this.converter.text(this.model[this.property]);
+};
+
+ConversionBinding.prototype.set = function(value) {
+  this.model[this.property] = this.converter.value(value);
+};
+
+function bindingObject(obj, prop) {
+  if (arguments.length > 2) {
+    return 
+  }
   var set =
     options && (typeof options === 'function'
     ? options
@@ -426,6 +475,23 @@ function bindingObject(obj, prop, options) {
       }
 
       obj[prop] = value;
+    },
+
+    meta: function () {
+      var plastiqMeta = obj._plastiqMeta;
+
+      if (!plastiqMeta) {
+        plastiqMeta = {};
+        Object.defineProperty(obj, '_plastiqMeta', {value: plastiqMeta});
+      }
+
+      var meta = plastiqMeta[prop];
+
+      if (!meta) {
+        meta = plastiqMeta[prop] = {};
+      }
+
+      return meta;
     }
   };
 };

--- a/rendering.js
+++ b/rendering.js
@@ -207,70 +207,71 @@ function insertEventHandler(attributes, eventName, handler, after) {
 
 function attachEventHandler(attributes, eventNames, handler) {
   if (eventNames instanceof Array) {
-    eventNames.forEach(function (eventName) {
-      insertEventHandler(attributes, eventName, handler);
-    });
+    for (var n = 0; n < eventNames.length; n++) {
+      insertEventHandler(attributes, eventNames[n], handler);
+    }
   } else {
     insertEventHandler(attributes, eventNames, handler);
   }
 }
 
-function bindModel(attributes, children, type) {
-  var inputTypeBindings = {
-    text: bindTextInput,
-    textarea: bindTextInput,
-    checkbox: function (attributes, children, get, set) {
-      attributes.checked = get();
+var inputTypeBindings = {
+  text: bindTextInput,
+  textarea: bindTextInput,
+  checkbox: function (attributes, children, get, set) {
+    attributes.checked = get();
 
-      attachEventHandler(attributes, 'onclick', function (ev) {
-        set(ev.target.checked);
-      });
-    },
-    radio: function (attributes, children, get, set) {
-      var value = attributes.value;
-      attributes.checked = get() == attributes.value;
+    attachEventHandler(attributes, 'onclick', function (ev) {
+      set(ev.target.checked);
+    });
+  },
+  radio: function (attributes, children, get, set) {
+    var value = attributes.value;
+    attributes.checked = get() == attributes.value;
 
-      attachEventHandler(attributes, 'onclick', function (ev) {
-        set(value);
-      });
-    },
-    select: function (attributes, children, get, set) {
-      var currentValue = get();
+    attachEventHandler(attributes, 'onclick', function (ev) {
+      set(value);
+    });
+  },
+  select: function (attributes, children, get, set) {
+    var currentValue = get();
 
-      var options = children.filter(function (child) {
-        return child.tagName.toLowerCase() == 'option';
-      });
+    var options = children.filter(function (child) {
+      return child.tagName.toLowerCase() == 'option';
+    });
 
-      var selectedOption = options.filter(function (child) {
-        return child.properties.value == currentValue;
-      })[0];
+    var selectedOption = options.filter(function (child) {
+      return child.properties.value == currentValue;
+    })[0];
 
-      var values = options.map(function (option) {
-        return option.properties.value;
-      });
+    var values = options.map(function (option) {
+      return option.properties.value;
+    });
 
-      options.forEach(function (option, index) {
-        option.properties.selected = option == selectedOption;
-        option.properties.value = index;
-      });
-
-      attachEventHandler(attributes, 'onchange', function (ev) {
-        set(values[ev.target.value]);
-      });
-    },
-    file: function (attributes, children, get, set) {
-      var multiple = attributes.multiple;
-
-      attachEventHandler(attributes, 'onchange', function (ev) {
-        if (multiple) {
-          set(ev.target.files);
-        } else {
-          set(ev.target.files[0]);
-        }
-      });
+    for(var n = 0; n < options.length; n++) {
+      var option = options[n];
+      option.properties.selected = option == selectedOption;
+      option.properties.value = n;
     }
-  };
 
+    attachEventHandler(attributes, 'onchange', function (ev) {
+      set(values[ev.target.value]);
+    });
+  },
+  file: function (attributes, children, get, set) {
+    var multiple = attributes.multiple;
+
+    attachEventHandler(attributes, 'onchange', function (ev) {
+      if (multiple) {
+        set(ev.target.files);
+      } else {
+        set(ev.target.files[0]);
+      }
+    });
+  }
+};
+
+function bindModel(attributes, children, type) {
   var bind = inputTypeBindings[type] || bindTextInput;
 
   var bindingAttr = makeBinding(attributes.binding);
@@ -430,7 +431,6 @@ function chainConverters(startIndex, converters) {
     var _converters;
     function makeConverters() {
       if (!_converters) {
-        console.log('converters.length', converters.length);
         _converters = new Array(converters.length - startIndex);
 
         for(var n = startIndex; n < converters.length; n++) {

--- a/rendering.js
+++ b/rendering.js
@@ -128,6 +128,7 @@ function refreshify(fn, options) {
   }
 
   var onlyRefreshAfterPromise = options && options.refresh == 'promise';
+  var componentToRefresh = options && options.component;
 
   if (options && (options.norefresh == true || options.refresh == false)) {
     return fn;
@@ -160,6 +161,8 @@ function refreshify(fn, options) {
           && typeof result.update === 'function'
           && typeof result.destroy === 'function') {
         refreshComponent(result, attachment);
+      } else if (componentToRefresh) {
+        refreshComponent(componentToRefresh, attachment);
       } else if (result === norefresh) {
         // don't refresh;
       } else if (allowRefresh) {

--- a/test/browser/plastiqSpec.js
+++ b/test/browser/plastiqSpec.js
@@ -438,7 +438,7 @@ describe('plastiq', function () {
       it('can bind with set conversion', function () {
         function render(model) {
           return h('div',
-            h('input', {type: 'text', binding: [model, 'number', {set: Number}]}),
+            h('input', {type: 'text', binding: [model, 'number', {value: Number}]}),
             h('span', model.number)
           );
         }

--- a/test/browser/plastiqSpec.js
+++ b/test/browser/plastiqSpec.js
@@ -1171,8 +1171,13 @@ describe('plastiq', function () {
     beforeEach(function () {
       refreshCalled = false;
       h.currentRender = {
-        refresh: function () {
+        refresh: function (component) {
           refreshCalled = true;
+          componentRefreshed = component;
+        },
+
+        requestRender: function (fn) {
+          fn();
         }
       };
     });
@@ -1207,6 +1212,22 @@ describe('plastiq', function () {
 
       it('normally calls refresh, even after a promise', function () {
         return expectPromiseToRefresh(undefined, true, true);
+      });
+    });
+
+    context('component: component', function () {
+      it('calls refresh with the component', function () {
+        var component = {
+          canRefresh: true,
+          update: function () {
+            this.wasRefreshed = true;
+          }
+        }
+
+        var model = {};
+        h.binding([model, 'field'], {component: component}).set('value');
+
+        expect(component.wasRefreshed).to.be.true;
       });
     });
 

--- a/test/browser/plastiqSpec.js
+++ b/test/browser/plastiqSpec.js
@@ -144,7 +144,6 @@ describe('plastiq', function () {
       selectorProduces('div.class', 'div.class');
       selectorProduces('div#id', 'div#id');
       selectorProduces('div.class#id', 'div.class#id');
-      selectorProduces('h1 a', 'h1 a');
     });
 
     describe('attribute naming exceptions', function () {
@@ -415,30 +414,20 @@ describe('plastiq', function () {
     });
 
     describe('binding options', function () {
-      it('can bind to a text input converting to number', function () {
-        function render(model) {
-          return h('div',
-            h('input', {type: 'text', binding: [model, 'number', Number]}),
-            h('span', model.number)
-          );
-        }
-
-        var model = {number: 0};
-        attach(render, model);
-
-        find('input').sendkeys('{selectall}{backspace}123');
-
-        return retry(function() {
-          expect(find('span').text()).to.equal('123');
-          expect(find('input').val()).to.equal('123');
-          expect(model.number).to.equal(123);
-        });
-      });
-
       it('can bind with set conversion', function () {
+        var numberConversion = {
+          value: function (text) {
+            return Number(text);
+          },
+
+          text: function (value) {
+            return String(value);
+          }
+        };
+
         function render(model) {
           return h('div',
-            h('input', {type: 'text', binding: [model, 'number', {value: Number}]}),
+            h('input', {type: 'text', binding: [model, 'number', numberConversion]}),
             h('span', model.number)
           );
         }

--- a/test/browser/plastiqSpec.js
+++ b/test/browser/plastiqSpec.js
@@ -746,6 +746,46 @@ describe('plastiq', function () {
       });
     });
 
+    it('can expose long-running state for components', function () {
+      var events = [];
+
+      function render(model) {
+        return h.component(
+          {
+            onbeforeadd: function () {
+              this.counter = 2;
+            }
+          },
+          function () {
+            var self = this;
+
+            return h('div',
+              h('span.counter', this.counter),
+              h('button.add', {onclick: function () { self.counter++; }}, 'add')
+            );
+          }
+        );
+      }
+
+      attach(render, {counter: 0});
+
+      return retry(function () {
+        expect(find('span.counter').text()).to.equal('2');
+      }).then(function () {
+        return click('button.add');
+      }).then(function () {
+        return retry(function () {
+          expect(find('span.counter').text()).to.equal('3');
+        });
+      }).then(function () {
+        return click('button.add');
+      }).then(function () {
+        return retry(function () {
+          expect(find('span.counter').text()).to.equal('4');
+        });
+      });
+    });
+
     it('renders and updates the vdom inside the component', function () {
       var events = [];
 

--- a/test/browser/plastiqSpec.js
+++ b/test/browser/plastiqSpec.js
@@ -144,6 +144,7 @@ describe('plastiq', function () {
       selectorProduces('div.class', 'div.class');
       selectorProduces('div#id', 'div#id');
       selectorProduces('div.class#id', 'div.class#id');
+      selectorProduces('h1 a', 'h1 a');
     });
 
     describe('attribute naming exceptions', function () {


### PR DESCRIPTION
Conversion bindings allow the textual representation of an input field, to be different to the model representation of an input field. This might be for date fields, numbers, or more complicated things like code editors for JSON or JS functions.

One of the problems with simply rendering a date as a string, and then parsing a string as a date is that the user cannot enter any non-encoded information. This might just an extra space, or the use of `/` instead of `-` in a date. That text isn't important to the model representation, so it's effectively thrown away at the next render. This is a problem when editing text, because those extra bits of text are essentially deleted as soon as you put them in - the result is an almost unusable UX.

This patch solves this by placing the intermediate textual representation into a **meta** area inside the model. This area is a non-enumerable property called `_plastiqMeta`, which is an object with properties of the same name as the model, but each property contains meta information about that model property. Currently we store `text` and `error` against each bound model property.

This branch also has some optimisations, and support for `refreshify({component: component})`