### PR TITLE
Allow event handlers to return arrays of components to refresh them

### DIFF
--- a/rendering.js
+++ b/rendering.js
@@ -173,6 +173,18 @@ function refreshify(fn, options) {
           && typeof result.update === 'function'
           && typeof result.destroy === 'function') {
         refreshComponent(result, attachment);
+      } else if (Object.prototype.toString.call(result) === '[object Array]'
+          && result.length > 0
+          && typeof result[0].init === 'function'
+          && typeof result[0].update === 'function'
+          && typeof result[0].destroy === 'function') {
+        for (var i = 0; i < result.length; i++) {
+          if(typeof result[i].init === 'function'
+              && typeof result[i].update === 'function'
+              && typeof result[i].destroy === 'function') {
+            refreshComponent(result[i], attachment);
+          }
+        }
       } else if (componentToRefresh) {
         refreshComponent(componentToRefresh, attachment);
       } else if (result === norefresh) {


### PR DESCRIPTION
Allow event handlers to return arrays of components to refresh them, not the entire view.
There might be much better ways to do it, I'm not well versed in JS by any means.